### PR TITLE
fix: username when value is 'nofullname'

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -88,12 +88,16 @@ const Header = ({ intl }) => {
     },
   ];
 
+  const userName = !authenticatedUser.name || authenticatedUser.name === 'nofullname'
+    ? authenticatedUser.username
+    : authenticatedUser.name;
+
   const props = {
     logo: config.LOGO_URL,
     logoAltText: config.SITE_NAME,
     logoDestination: `${config.LMS_BASE_URL}/dashboard`,
     loggedIn: authenticatedUser !== null,
-    username: authenticatedUser !== null ? authenticatedUser?.name || authenticatedUser.username : null,
+    username: authenticatedUser !== null ? userName : null,
     avatar: authenticatedUser !== null ? authenticatedUser.avatar : null,
     mainMenu: getConfig().AUTHN_MINIMAL_HEADER ? [] : mainMenu,
     userMenu: getConfig().AUTHN_MINIMAL_HEADER ? [] : userMenu,


### PR DESCRIPTION
# Description  

This PR resolves [PADV-2063](https://agile-jira.pearson.com/browse/PADV-2063)  

## Change log  
- Fixed an issue where the header displayed `nofullname` when the authenticated user's `name` existed but contained that value.  

### How to test 
First of all, follow this instructions to configure the header locally: https://github.com/Pearson-Advance/frontend-component-header/pull/1#issue-2901572715 
1. Use a test user whose `user.profile.name` field is set. The header should display that name.  
2. Use another test user with no value set for `user.profile.name` or with `"nofullname"`. The header should now display the `username` instead.  
3. Verify that removing the `user.profile.name` value also results in the `username` being displayed.  
