### PR TITLE
feat: full username in header v4.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@edx/frontend-component-header",
-  "version": "1.0.0-semantically-released",
+  "name": "@pearsonedunext/frontend-component-header",
+  "version": "4.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@edx/frontend-component-header",
-      "version": "1.0.0-semantically-released",
+      "name": "@pearsonedunext/frontend-component-header",
+      "version": "4.11.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@edx/frontend-component-header",
-  "version": "1.0.0-semantically-released",
+  "name": "@pearsonedunext/frontend-component-header",
+  "version": "4.11.2",
   "description": "The standard header for Open edX",
   "main": "dist/index.js",
   "publishConfig": {
@@ -24,14 +24,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openedx/frontend-component-header.git"
+    "url": "git+https://github.com/Pearson-Advance/frontend-component-header.git"
   },
   "author": "edX",
   "license": "AGPL-3.0",
   "bugs": {
-    "url": "https://github.com/openedx/frontend-component-header/issues"
+    "url": "https://github.com/Pearson-Advance/frontend-component-header/issues"
   },
-  "homepage": "https://github.com/openedx/frontend-component-header#readme",
+  "homepage": "https://github.com/Pearson-Advance/frontend-component-header#readme",
   "devDependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/browserslist-config": "^1.1.1",

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -93,7 +93,7 @@ const Header = ({ intl }) => {
     logoAltText: config.SITE_NAME,
     logoDestination: `${config.LMS_BASE_URL}/dashboard`,
     loggedIn: authenticatedUser !== null,
-    username: authenticatedUser !== null ? authenticatedUser.username : null,
+    username: authenticatedUser !== null ? authenticatedUser.name || authenticatedUser.username : null,
     avatar: authenticatedUser !== null ? authenticatedUser.avatar : null,
     mainMenu: getConfig().AUTHN_MINIMAL_HEADER ? [] : mainMenu,
     userMenu: getConfig().AUTHN_MINIMAL_HEADER ? [] : userMenu,

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -1,15 +1,20 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUserCircle } from '@fortawesome/free-solid-svg-icons';
 import { getConfig } from '@edx/frontend-platform';
+import { AppContext } from '@edx/frontend-platform/react';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Dropdown } from '@openedx/paragon';
 
 import messages from './messages';
 
 const AuthenticatedUserDropdown = ({ intl, username }) => {
+  const { authenticatedUser } = useContext(AppContext);
+
+  const displayName = authenticatedUser?.name || username;
+
   const dashboardMenuItem = (
     <Dropdown.Item href={`${getConfig().LMS_BASE_URL}/dashboard`}>
       {intl.formatMessage(messages.dashboard)}
@@ -23,7 +28,7 @@ const AuthenticatedUserDropdown = ({ intl, username }) => {
         <Dropdown.Toggle variant="outline-primary">
           <FontAwesomeIcon icon={faUserCircle} className="d-md-none" size="lg" />
           <span data-hj-suppress className="d-none d-md-inline">
-            {username}
+            {displayName}
           </span>
         </Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu-right">

--- a/src/learning-header/LearningHeader.test.jsx
+++ b/src/learning-header/LearningHeader.test.jsx
@@ -12,7 +12,7 @@ describe('Header', () => {
 
   it('displays user button', () => {
     render(<Header />);
-    expect(screen.getByText(authenticatedUser.username)).toBeInTheDocument();
+    expect(screen.getByText(authenticatedUser.name)).toBeInTheDocument();
   });
 
   it('displays course data', () => {

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -48,6 +48,7 @@ class MockLoggingService {
 export const authenticatedUser = {
   userId: 'abc123',
   username: 'Mock User',
+  name: 'Mock User Name',
   roles: [],
   administrator: false,
 };
@@ -70,6 +71,7 @@ export function initializeMockApp() {
     authenticatedUser: {
       userId: 'abc123',
       username: 'Mock User',
+      name: 'Mock User Name',
       roles: [],
       administrator: false,
     },


### PR DESCRIPTION
# Description  

This PR updates the **header** to display the user's full name **using the version** `4.11.1` of https://github.com/openedx/frontend-component-header instead of their username.


> [!IMPORTANT]  
> The reason this is done is because version `4.2.3` was previously being used, which caused issues when running the `Learning` and `Discussions` MFEs ( using devstack and tutor ). As a scalable alternative, this version was chosen instead, as it has proven to be stable across all platform MFEs.



This PR resolves [PADV-2063](https://agile-jira.pearson.com/browse/PADV-2063)  

## Change log  
- Updated the header to display the **full name** instead of the username in `src/Header.jsx.`  
- If the full name is not available, the username remains as the fallback.  

### Visual results  
![image](https://github.com/user-attachments/assets/b498062b-4770-4c9f-88b0-c3cafc2017d4)

### How to test  
> [!WARNING]  
> Devstack must be running!

#### 1. For fast results use the mfe profile:  https://github.com/openedx/frontend-app-profile

```sh
git clone https://github.com/openedx/frontend-app-profile
cd frontend-app-profile
```

#### 2. Checkout the branch  

```sh
git checkout open-release/olive.master
```

#### 3. Install dependencies  

```sh
nvm use ; npm i
```

#### 4. Clone this repository and install deps
```sh
# Not forget to make checkout to branch v4.11.1-2063
nvm use ; npm i ; npm run build
```

#### 5. Get back to profile mfe and configure module resolution  
Create a file named `module.config.js` in the root of the **frontend-app-profile** project and add the following configuration:

```js
module.exports = {
  localModules: [
    { moduleName: '@edx/frontend-component-header/dist', dir: '../frontend-component-header', dist: 'src' },
    { moduleName: '@edx/frontend-component-header', dir: '../frontend-component-header', dist: 'src' },
  ],
};
```

This configuration assumes the following project structure:

```
├── frontend-app-profile
├── frontend-component-header
```

If your setup differs, **adjust the paths accordingly**.

> [!NOTE]  
> For a more realistic environment, install the package [brand-pearson.com](https://github.com/Pearson-Advance/brand-pearson.com) locally.

```shell
npm install @edx/brand@git+ssh://git@github.com:Pearson-Advance/brand-pearson.com.git#v0.3.0
``` 


#### Finally, start the frontend-app-profile mfe
```shell
npm start 
``` 

If everything went good, you should be able to see the changes in the header using this link http://localhost:1995/
