### PR TITLE
feat: dropdown custom options by userole

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
 import Responsive from 'react-responsive';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
@@ -9,6 +10,8 @@ import {
   getConfig,
   subscribe,
 } from '@edx/frontend-platform';
+
+import useGetMenuOptionsByRole from './hooks';
 
 import DesktopHeader from './DesktopHeader';
 import MobileHeader from './MobileHeader';
@@ -30,8 +33,10 @@ subscribe(APP_CONFIG_INITIALIZED, () => {
   }, 'Header additional config');
 });
 
-const Header = ({ intl }) => {
+const Header = ({ intl, appID }) => {
   const { authenticatedUser, config } = useContext(AppContext);
+
+  const itemsByRole = useGetMenuOptionsByRole(appID);
 
   const mainMenu = [
     {
@@ -53,6 +58,7 @@ const Header = ({ intl }) => {
       href: `${config.LMS_BASE_URL}/dashboard`,
       content: intl.formatMessage(messages['header.user.menu.dashboard']),
     },
+    ...itemsByRole,
     {
       type: 'item',
       href: `${config.ACCOUNT_PROFILE_URL}/u/${authenticatedUser.username}`,
@@ -114,6 +120,11 @@ const Header = ({ intl }) => {
 
 Header.propTypes = {
   intl: intlShape.isRequired,
+  appID: PropTypes.string,
+};
+
+Header.defaultProps = {
+  appID: 'header-component',
 };
 
 export default injectIntl(Header);

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,0 +1,26 @@
+const EDX_HEADER_COOKIE_PAYLOAD = 'edx-jwt-cookie-header-payload';
+const DEFAULT_ROLES = [];
+
+function getCookie(name) {
+  return document.cookie
+    .split('; ')
+    .map(c => c.split('='))
+    .find(([key]) => key === name)?.[1] || null;
+}
+
+function getUserRolesFromCookie() {
+  let roles = DEFAULT_ROLES;
+  const headerPayload = getCookie(EDX_HEADER_COOKIE_PAYLOAD);
+
+  if (headerPayload) {
+    const [, payload] = headerPayload.split('.')
+      .map(part => JSON.parse(atob(part.replace(/-/g, '+').replace(/_/g, '/'))));
+    roles = payload?.extra_data?.permission_roles || DEFAULT_ROLES;
+
+    return roles;
+  }
+
+  return roles;
+}
+
+export { getUserRolesFromCookie, DEFAULT_ROLES };

--- a/src/hooks/index.jsx
+++ b/src/hooks/index.jsx
@@ -1,0 +1,99 @@
+import { useState, useEffect } from 'react';
+import { initialize, mergeConfig, getConfig } from '@edx/frontend-platform';
+
+import { getUserRolesFromCookie, DEFAULT_ROLES } from '../helpers';
+
+const GLOBAL_STAFF = 'GLOBAL_STAFF';
+const INSTITUTION_ADMIN = 'INSTITUTION_ADMIN';
+const INSTRUCTOR = 'INSTRUCTOR';
+const ROLES_PRIORITY = [GLOBAL_STAFF, INSTITUTION_ADMIN, INSTRUCTOR];
+
+function useInitializeConfig(appID) {
+  useEffect(() => {
+    initialize({
+      messages: [],
+      requireAuthenticatedUser: true,
+      handlers: {
+        config: () => {
+          const configOptions = {
+            MFE_CONFIG_API_URL: `${process.env.LMS_BASE_URL}/api/mfe_config/v1`,
+          };
+
+          if (appID) {
+            configOptions.APP_ID = appID;
+          }
+
+          mergeConfig(configOptions);
+        },
+      },
+    });
+  }, [appID]);
+}
+
+function getUserLinksByRole(userRoles, paths) {
+  const { instructorPath, institutionPath } = paths;
+
+  const CERTPREP_MANAGER_ITEM = {
+    type: 'item',
+    href: institutionPath,
+    content: 'Skilling Administrator',
+  };
+
+  const INSTRUCTOR_PORTAL_ITEM = {
+    type: 'item',
+    href: instructorPath,
+    content: 'Instructor Portal',
+  };
+
+  const ROLES_PERMISSIONS = {
+    GLOBAL_STAFF: [CERTPREP_MANAGER_ITEM],
+    INSTITUTION_ADMIN: [CERTPREP_MANAGER_ITEM],
+    INSTRUCTOR: [INSTRUCTOR_PORTAL_ITEM],
+  };
+
+  const roles = Array.isArray(userRoles) ? userRoles : [userRoles];
+  const validRoles = roles.filter(role => ROLES_PRIORITY.includes(role));
+
+  if (!validRoles.length) { return DEFAULT_ROLES; }
+
+  const sortedRoles = validRoles.sort(
+    (a, b) => ROLES_PRIORITY.indexOf(a) - ROLES_PRIORITY.indexOf(b),
+  );
+
+  const highestRole = sortedRoles[0];
+
+  if ((highestRole === GLOBAL_STAFF || highestRole === INSTITUTION_ADMIN) && roles.includes(INSTRUCTOR)) {
+    return [...(ROLES_PERMISSIONS[highestRole] || []), INSTRUCTOR_PORTAL_ITEM];
+  }
+
+  return ROLES_PERMISSIONS[highestRole] || [];
+}
+
+function useGetMenuOptionsByRole(appID) {
+  const enableDropDownSettings = getConfig().ENABLE_DROPDOWN_CUSTOM_OPTIONS;
+  const [userLinks, setUserLinks] = useState([]);
+
+  useInitializeConfig(appID);
+
+  const instructorPath = getConfig().INSTRUCTOR_PORTAL_PATH;
+  const institutionPath = getConfig().INSTITUTION_PORTAL_PATH;
+
+  useEffect(() => {
+    if (!enableDropDownSettings) {
+      setUserLinks([]);
+      return;
+    }
+
+    const roles = getUserRolesFromCookie();
+    const menuOptions = getUserLinksByRole(roles, {
+      instructorPath,
+      institutionPath,
+    });
+
+    setUserLinks(menuOptions);
+  }, [instructorPath, institutionPath, enableDropDownSettings]);
+
+  return userLinks;
+}
+
+export default useGetMenuOptionsByRole;

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -9,9 +9,11 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Dropdown } from '@openedx/paragon';
 
 import messages from './messages';
+import useGetMenuOptionsByRole from '../hooks';
 
 const AuthenticatedUserDropdown = ({ intl, username }) => {
   const { authenticatedUser } = useContext(AppContext);
+  const itemsByRole = useGetMenuOptionsByRole();
 
   const displayName = authenticatedUser?.name || username;
 
@@ -33,6 +35,11 @@ const AuthenticatedUserDropdown = ({ intl, username }) => {
         </Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu-right">
           {dashboardMenuItem}
+          {itemsByRole.map(({ href, content }) => (
+            <Dropdown.Item key={href} href={href}>
+              {content}
+            </Dropdown.Item>
+          ))}
           <Dropdown.Item href={`${getConfig().ACCOUNT_PROFILE_URL}/u/${username}`}>
             {intl.formatMessage(messages.profile)}
           </Dropdown.Item>


### PR DESCRIPTION
# Description

In this PR is added new options based on the user role in the dropdown settings for base header and learning header.

Resolves [PADV-2188](https://agile-jira.pearson.com/browse/PADV-2188)

## Change log
- Added options for `Header` and `LearningHeader`

### Visual results
![localhost_2002_course-v1_demo+cs101+t1_posts](https://github.com/user-attachments/assets/4bf7d29e-ac9c-40b6-a8d4-f3abe77c27c9)


### How to test
Follow the instructions of this PR https://github.com/Pearson-Advance/frontend-component-header/pull/7

2. In the site configs, add this new setting
```javascript
"MFE_CONFIG": {
     "ENABLE_DROPDOWN_CUSTOM_OPTIONS": true
},
``` 