### PR TITLE
fix: update exam dashboard URL in header component and tests

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -47,7 +47,7 @@ const Header = ({ intl, appID }) => {
     },
     mfeConfigs.ENABLE_EXAM_DASHBOARD && {
       type: 'item',
-      href: `${mfeConfigs.EXAM_DASHBOARD_MFE_BASE_URL}/dashboard`,
+      href: `${mfeConfigs.WEBNG_EXAM_MFE_BASE_URL}/dashboard`,
       content: intl.formatMessage(messages['header.links.exams']),
     },
   ].filter(Boolean);

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -18,7 +18,7 @@ jest.mock('./hooks', () => ({
   default: jest.fn(() => []),
   useGetMFEConfig: jest.fn(() => ({
     ENABLE_EXAM_DASHBOARD: false,
-    EXAM_DASHBOARD_MFE_BASE_URL: 'http://localhost:1994',
+    WEBNG_EXAM_MFE_BASE_URL: 'http://localhost:1994',
   })),
 }));
 
@@ -125,7 +125,7 @@ describe('<Header />', () => {
   it('renders exam dashboard link when ENABLE_EXAM_DASHBOARD is true (desktop)', () => {
     useGetMFEConfig.mockReturnValue({
       ENABLE_EXAM_DASHBOARD: true,
-      EXAM_DASHBOARD_MFE_BASE_URL: 'http://localhost:1994',
+      WEBNG_EXAM_MFE_BASE_URL: 'http://localhost:1994',
     });
 
     const contextValue = {
@@ -156,7 +156,7 @@ describe('<Header />', () => {
   it('renders exam dashboard link when ENABLE_EXAM_DASHBOARD is true (mobile)', () => {
     useGetMFEConfig.mockReturnValue({
       ENABLE_EXAM_DASHBOARD: true,
-      EXAM_DASHBOARD_MFE_BASE_URL: 'http://localhost:1994',
+      WEBNG_EXAM_MFE_BASE_URL: 'http://localhost:1994',
     });
 
     const contextValue = {


### PR DESCRIPTION
This pull request updates the configuration and usage of the exam dashboard micro-frontend (MFE) in the header component and its related tests. The main change is switching from `EXAM_DASHBOARD_MFE_BASE_URL` to `WEBNG_EXAM_MFE_BASE_URL` for the exam dashboard link, ensuring consistency with the latest configuration naming.

Configuration update:

* Replaced all occurrences of `EXAM_DASHBOARD_MFE_BASE_URL` with `WEBNG_EXAM_MFE_BASE_URL` in the `Header` component logic to update the exam dashboard link URL.

Test updates:

* Updated mock configuration in `Header.test.jsx` to use `WEBNG_EXAM_MFE_BASE_URL` instead of the old variable name.
* Modified test cases for desktop and mobile rendering to use the new `WEBNG_EXAM_MFE_BASE_URL` configuration. [[1]](diffhunk://#diff-2f7ef3554de216de0dfa3e78ed36e8aec9dcda3effbbdb72bb6b2f92e81fb849L128-R128) [[2]](diffhunk://#diff-2f7ef3554de216de0dfa3e78ed36e8aec9dcda3effbbdb72bb6b2f92e81fb849L159-R159)

### For more information
Taking into consideration this is a minor fix, in case you need information for testing or additional information please go to https://github.com/Pearson-Advance/frontend-component-header/pull/10 and remember to replace the `EXAM_DASHBOARD_MFE_BASE_URL` usage with `WEBNG_EXAM_MFE_BASE_URL`